### PR TITLE
fix: getStaticPaths is required for dynamic SSG pages and is missing …

### DIFF
--- a/src/pages/product/[id].tsx
+++ b/src/pages/product/[id].tsx
@@ -61,6 +61,13 @@ export default function Product({ product }: ProductProps) {
   );
 }
 
+export const getStaticPaths: GetStaticPaths<{ slug: string }> = async () => {
+  return {
+    paths: [],
+    fallback: "blocking",
+  };
+};
+
 export const getStaticProps: GetStaticProps<any, { id: string }> = async ({
   params,
 }) => {


### PR DESCRIPTION
…for '/product/[id]'.